### PR TITLE
Update extras-5.md

### DIFF
--- a/use-cases/extras/5/extras-5.md
+++ b/use-cases/extras/5/extras-5.md
@@ -16,8 +16,4 @@ Because of the nature of promises and the fact a `catch` handler can be attached
 ### What should we maybe do better?
 
 There was a lot of interesting work done by @addaleax on this.
-
-Note that in the 3+ years we've had promises in Node.js literally not a single user complained about this in Node.js or the bluebird/q/when/rsvp tracker as far as I know. 
-
-It is still important to some stakeholders and worth discussing.
   


### PR DESCRIPTION
After reading this comment, I walk away feeling like the things I have cared about for a long time aren't taken seriously by the author, though I suspect that was not the intent.

Promises changing the state of a process before it exits has been a known problem for nearly as long as I've been in the Node.js community, and effort has been invested by quite a few people (i.e. the amazing @addaleax!) in this space.

https://github.com/nodejs/post-mortem/issues/45 (speaks directly to it as if it were a known long-standing issue)
https://github.com/nodejs/promises/issues/26 (doesn't reference core dumps but speaks to changing state on process exit)

We are still resisting promises in the restify codebase due to this class of problem: https://github.com/restify/node-restify/issues/1304

I do think it is fair to say:

* Those with a vested interest in operating Node.js in production at scale haven't shown up with the resources to solve for operating promises. I'm starting to see this change (yay!).
* Many of conversations around this happened outside of the Node.js issue tracker, often in echo chambers and hallway tracks. If you weren't actively looking for these concerns, they would have been easy to miss. I believe this is already changing (also yay!).

I also think it is fair to say:

* Many of those who had a vested interest in operating Node.js in production at scale _did_ show up and broadcast their concerns about the form of the promises specification when it was being proposed. The ones I saw were met with something between dismissal and hostility.
* Those I know who _did_ show up left this feeling as if promises in their current form were both rushed through the specification process and forced upon this part of the community without much regard for their input. After this, many wholesale rejected promises as a viable primitive which left adoption to be driven by those who didn't have this class of concern. To put it another way, if you cared about post-mortem and your concerns weren't heard for the spec, you didn't use promises and since you didn't use promises you wouldn't be actively engaging in issue trackers about promises.

I don't bring up these two points to add fuel to an old argument, but to try to cultivate empathy for why these concerns are only now starting to shake out of the woodwork from some people's perspectives. The part of the community that cares about this class of problem - and that we want investment from to solve this class of problem - was ostracized early on in the story of promises. We should be making efforts to draw those who abandoned promises back into the community, I don't believe the tone of this section advances that cause.