### PR TITLE
use-cases: add README with summary of use cases

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@ The goal is to provide feedback to Node.js and V8 in order to possibly expose AP
 
 This is to discuss diagnostic/debugging experience that could be done better.
 
-Please see [the meeting discussion](./meeting-discussion.md) for current use cases we have.
+Please see [the meeting discussion](./meeting-discussion.md) and 
+[the use cases folder](./use-cases/) for current use cases we have.
 
 ### Contributing
 

--- a/use-cases/README.md
+++ b/use-cases/README.md
@@ -1,0 +1,69 @@
+# Use Cases Summary
+
+## Extras
+
+| Use Case                                                      | Current State | Related Links |
+|---------------------------------------------------------------|---------------|---------------|
+| [1 - Userland Features](./extras/1/extras-1.md)               |               |               |
+| [2 - APIs for controlling operations](./extras/2/extras-2.md) |               |               |
+| [3 - Unsubscribe Listeners](./extras/3/extras-3.md)           |               |               |
+| [4 - Short Circuit](./extras/4/extras-4.md)                   |               |               |
+| [5 - Postmortem](./extras/5/extras-5.md)                      |               |               |
+
+## Forgotten Promises
+
+| Use Case                                                                   | Current State | Related Links |
+|----------------------------------------------------------------------------|---------------|---------------|
+| [1 - Address Promises "in a scope"](./forgotten-promises/1/forgotten-1.md) |               |               |
+
+## Performance
+
+| Use Case                                                   | Current State | Related Links |
+|------------------------------------------------------------|---------------|---------------|
+| [1 - Userland Libraries](./performance/1/performance-1.md) |               |               |
+| [2 - Async Iterators](./performance/2/performance-2.md)    |               |               |
+
+## Stack Trace
+
+| Use Case                                                                  | Current State | Related Links |
+|---------------------------------------------------------------------------|---------------|---------------|
+| [1 - Missing Stack Trace](./stack-traces/1/stack-traces-1.md)             |               |               |
+| [2 - Async Stack Trace in Production](./stack-traces/2/stack-traces-2.md) |               |               |
+| [3 - Action on Rejection](./stack-traces/3/stack-traces-3.md)             |               |               |
+
+## Testing
+
+| Use Case                                                     | Current State | Related Links |
+|--------------------------------------------------------------|---------------|---------------|
+| [1 - Fake Timers](./testing/testing-1/testing-1.md)          |               |               |
+| [2 - Test Synchronization](./testing/testing-2/testing-2.md) |               |               |
+
+## Unhandled Rejections
+
+| Use Case                                                                                                               | Current State | Related Links |
+|------------------------------------------------------------------------------------------------------------------------|---------------|---------------|
+| [1 - Heuristic Issues](./unhandled-rejections/unhandled-rejections-1/unhandled-rejections-1.md)                        |               |               |
+| [2 - Throw on GC](./unhandled-rejections/unhandled-rejections-2/unhandled-rejections-2.md)                             |               |               |
+| [3 - Untrusted Unhandled Rejection Detection](./unhandled-rejections/unhandled-rejections-3/unhandled-rejections-3.md) |               |               |
+
+## User Expectations
+
+| Use Case                                                                             | Current State | Related Links |
+|--------------------------------------------------------------------------------------|---------------|---------------|
+| [1 - Promisify Core](./user-expectations/1/expectations-1.md)                        |               |               |
+| [2 - Promisification](./user-expectations/2/expectations-2.md)                       |               |               |
+| [3 - Queue Documentation](./user-expectations/3/expectations-3.md)                   |               |               |
+| [4 - `.forEach`](./user-expectations/4/expectations-4.md)                            |               |               |
+| [5 - Extract `resolve`/`reject`](./user-expectations/5/expectations-5.md)            |               |               |
+| [6 - Reject after Resolve on `constructor`](./user-expectations/6/expectations-6.md) |               |               |
+
+## Warnings
+
+| Use Case                                                    | Current State | Related Links |
+|-------------------------------------------------------------|---------------|---------------|
+| [1 - Return on `.then`/`async`](./warnings/1/1.md)          |               |               |
+| [2 - Forgot `await` inside `async`](./warnings/2/2.md)      |               |               |
+| [3 - Reject and Resolve on `constuctor`](./warnings/3/3.md) |               |               |
+| [4 - Never Resolve](./warnings/4/4.md)                      |               |               |
+| [5 - Exit with pending Promises](./warnings/5/5.md)         |               |               |
+


### PR DESCRIPTION
Navigating through our use cases from GitHub's interface is clumsy since
use cases are separated in subfolders inside category folders (to open
one use case it takes 3 URL clicks). This commit summarizes all use
cases we have in a README file inside `use-cases/` for easy access and
easy visualization of the current state of each use case.